### PR TITLE
set ruby version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,10 @@
 machine:
   php:
     version: 5.5.11
+  ruby:
+    version: 2.0.0-p247
+  timezone: Asia/Tokyo
+
 general:
   artifacts:
       - "app/reports"


### PR DESCRIPTION
set ruby version to install berkshelf. (NOTE: Berkshelf is not required for deploying application, however, it is required by infrastructural scripts.)